### PR TITLE
Hotfix/62 query notices error

### DIFF
--- a/src/main/kotlin/entry/dsm/gitauth/equusgithubauth/domain/notice/command/service/CreateNoticeService.kt
+++ b/src/main/kotlin/entry/dsm/gitauth/equusgithubauth/domain/notice/command/service/CreateNoticeService.kt
@@ -17,7 +17,7 @@ class CreateNoticeService(
             Notice(
                 noticeId = command.noticeId,
                 title = command.title,
-                keyWord = command.keyWord,
+                keyWord = command.keyWord.toMutableList(),
                 titleImageUrl = command.titleImageUrl,
                 descriptions = mutableListOf(),
                 isFocusRecruit = command.isFocusRecruit,

--- a/src/main/kotlin/entry/dsm/gitauth/equusgithubauth/domain/notice/entity/Notice.kt
+++ b/src/main/kotlin/entry/dsm/gitauth/equusgithubauth/domain/notice/entity/Notice.kt
@@ -21,11 +21,11 @@ class Notice(
     val noticeId: Long,
     @Column(name = "title", nullable = false)
     var title: String,
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "notice_keywords", joinColumns = [JoinColumn(name = "notice_id")])
     @Column(name = "key_word", nullable = false)
-    var keyWord: List<String>,
-    @Column(name = "title_image_url", nullable = false)
+    var keyWord: MutableList<String> = mutableListOf(),
+    @Column(name = "title_image_url")
     var titleImageUrl: String,
     @OneToMany(mappedBy = "notice", cascade = [CascadeType.ALL], orphanRemoval = true)
     var descriptions: MutableList<NoticeDescription> = mutableListOf(),
@@ -38,7 +38,7 @@ class Notice(
 ) {
     fun update(command: UpdateNoticeCommand) {
         title = command.title
-        keyWord = command.keyWord
+        keyWord = command.keyWord.toMutableList()
         titleImageUrl = command.titleImageUrl
         isFocusRecruit = command.isFocusRecruit
         isImportant = command.isImportant


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #62

## 📝작업 내용

> `/notices` 엔드포인트를 통해 `notice`를 전체 조회하였을 때 500이 뜨는 에러 수정.

## 💬리뷰 요구사항(선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 공지사항 작성 시 제목 이미지를 선택적으로 등록할 수 있게 되어, 사용 편의성이 향상되었습니다.
- **리팩토링**
	- 공지사항 키워드 관리 방식이 개선되어, 키워드 수정 및 업데이트가 보다 유연해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->