### PR TITLE
Feature/66 modify GitHub oauth

### DIFF
--- a/src/main/kotlin/entry/dsm/gitauth/equusgithubauth/domain/auth/command/service/GenerateGithubTokenService.kt
+++ b/src/main/kotlin/entry/dsm/gitauth/equusgithubauth/domain/auth/command/service/GenerateGithubTokenService.kt
@@ -1,7 +1,8 @@
 package entry.dsm.gitauth.equusgithubauth.domain.auth.command.service
 
-import entry.dsm.gitauth.equusgithubauth.domain.auth.command.dto.response.GithubAccessTokenResponse
 import entry.dsm.gitauth.equusgithubauth.domain.auth.exception.GitHubOAuthException
+import entry.dsm.gitauth.equusgithubauth.domain.user.presentation.dto.response.LoginSuccessResponse
+import entry.dsm.gitauth.equusgithubauth.domain.user.service.UserService
 import entry.dsm.gitauth.equusgithubauth.global.external.github.presentation.controller.GithubOAuthApiClient
 import entry.dsm.gitauth.equusgithubauth.global.oauth.properties.GithubRegistrationProperties
 import org.springframework.stereotype.Service
@@ -10,18 +11,19 @@ import org.springframework.stereotype.Service
 class GenerateGithubTokenService(
     private val githubOAuthApiClient: GithubOAuthApiClient,
     private val githubRegistrationProperties: GithubRegistrationProperties,
+    private val userService: UserService
 ) {
-    fun execute(code: String): GithubAccessTokenResponse {
+    fun execute(code: String): LoginSuccessResponse {
         try {
-            val response =
+            val githubAccessToken =
                 githubOAuthApiClient.codeToToken(
                     redirectUrl = githubRegistrationProperties.redirectUrl,
                     clientSecret = githubRegistrationProperties.clientSecret,
                     clientId = githubRegistrationProperties.clientId,
                     code = code,
-                )
+                ).accessToken
 
-            return GithubAccessTokenResponse(response.accessToken)
+            return userService.execute(githubAccessToken)
         } catch (e: Exception) {
             throw GitHubOAuthException()
         }

--- a/src/main/kotlin/entry/dsm/gitauth/equusgithubauth/domain/auth/command/service/GitHubOauthService.kt
+++ b/src/main/kotlin/entry/dsm/gitauth/equusgithubauth/domain/auth/command/service/GitHubOauthService.kt
@@ -8,7 +8,7 @@ import entry.dsm.gitauth.equusgithubauth.global.oauth.properties.GithubRegistrat
 import org.springframework.stereotype.Service
 
 @Service
-class GenerateGithubTokenService(
+class GitHubOauthService(
     private val githubOAuthApiClient: GithubOAuthApiClient,
     private val githubRegistrationProperties: GithubRegistrationProperties,
     private val userService: UserService

--- a/src/main/kotlin/entry/dsm/gitauth/equusgithubauth/domain/auth/presentation/controller/GithubAuthenticationController.kt
+++ b/src/main/kotlin/entry/dsm/gitauth/equusgithubauth/domain/auth/presentation/controller/GithubAuthenticationController.kt
@@ -16,8 +16,7 @@ import org.springframework.web.servlet.view.RedirectView
 @RestController
 @RequestMapping("/api/github/auth")
 class GithubAuthenticationController(
-    private val generateGithubTokenService: GenerateGithubTokenService,
-    private val userService: UserService,
+    private val gitHubOauthService: GitHubOauthService,
     private val githubAuthProperties: GithubAuthProperties,
 ) {
     @GetMapping
@@ -28,11 +27,11 @@ class GithubAuthenticationController(
     @GetMapping("/login/oauth2/code/github")
     fun githubCallback(
         @RequestParam("code") code: String,
-    ): GithubAccessTokenResponse {
+    ): LoginSuccessResponse {
         if (code.isBlank()) {
             throw InvalidAuthorizationCodeException()
         }
-        return generateGithubTokenService.execute(code)
+        return gitHubOauthService.execute(code)
     }
 
     @GetMapping("/not/authentication")

--- a/src/main/kotlin/entry/dsm/gitauth/equusgithubauth/domain/auth/presentation/controller/GithubAuthenticationController.kt
+++ b/src/main/kotlin/entry/dsm/gitauth/equusgithubauth/domain/auth/presentation/controller/GithubAuthenticationController.kt
@@ -1,13 +1,10 @@
 package entry.dsm.gitauth.equusgithubauth.domain.auth.presentation.controller
 
-import entry.dsm.gitauth.equusgithubauth.domain.auth.command.dto.response.GithubAccessTokenResponse
 import entry.dsm.gitauth.equusgithubauth.domain.auth.command.service.GitHubOauthService
 import entry.dsm.gitauth.equusgithubauth.domain.auth.exception.InvalidAuthorizationCodeException
 import entry.dsm.gitauth.equusgithubauth.domain.user.presentation.dto.response.LoginSuccessResponse
-import entry.dsm.gitauth.equusgithubauth.domain.user.service.UserService
 import entry.dsm.gitauth.equusgithubauth.global.oauth.properties.GithubAuthProperties
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController

--- a/src/main/kotlin/entry/dsm/gitauth/equusgithubauth/domain/auth/presentation/controller/GithubAuthenticationController.kt
+++ b/src/main/kotlin/entry/dsm/gitauth/equusgithubauth/domain/auth/presentation/controller/GithubAuthenticationController.kt
@@ -1,8 +1,7 @@
 package entry.dsm.gitauth.equusgithubauth.domain.auth.presentation.controller
 
 import entry.dsm.gitauth.equusgithubauth.domain.auth.command.dto.response.GithubAccessTokenResponse
-import entry.dsm.gitauth.equusgithubauth.domain.auth.command.service.GenerateGithubTokenService
-import entry.dsm.gitauth.equusgithubauth.domain.auth.exception.InvalidAccessTokenException
+import entry.dsm.gitauth.equusgithubauth.domain.auth.command.service.GitHubOauthService
 import entry.dsm.gitauth.equusgithubauth.domain.auth.exception.InvalidAuthorizationCodeException
 import entry.dsm.gitauth.equusgithubauth.domain.user.presentation.dto.response.LoginSuccessResponse
 import entry.dsm.gitauth.equusgithubauth.domain.user.service.UserService
@@ -34,23 +33,6 @@ class GithubAuthenticationController(
             throw InvalidAuthorizationCodeException()
         }
         return generateGithubTokenService.execute(code)
-    }
-
-    @GetMapping("/authentication")
-    fun githubLoginSuccess(
-        @RequestHeader("Authorization") accessToken: String,
-    ): LoginSuccessResponse {
-        if (accessToken.isBlank()) {
-            throw InvalidAccessTokenException()
-        }
-        val token =
-            accessToken.trim().let {
-                if (it.startsWith("Bearer ")) it.substring(7) else it
-            }
-        if (token.isBlank()) {
-            throw InvalidAccessTokenException()
-        }
-        return userService.execute(token)
     }
 
     @GetMapping("/not/authentication")

--- a/src/main/kotlin/entry/dsm/gitauth/equusgithubauth/domain/auth/presentation/controller/GithubAuthenticationController.kt
+++ b/src/main/kotlin/entry/dsm/gitauth/equusgithubauth/domain/auth/presentation/controller/GithubAuthenticationController.kt
@@ -19,7 +19,7 @@ class GithubAuthenticationController(
     private val gitHubOauthService: GitHubOauthService,
     private val githubAuthProperties: GithubAuthProperties,
 ) {
-    @GetMapping
+    @GetMapping("/authentication")
     fun githubAuth(): RedirectView {
         return RedirectView(githubAuthProperties.redirectUrl)
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #66

## 📝작업 내용

> `GitHub OAuth`를 통하여 로그인을 하면 바로 `accessToken`과 `refrehToken`이 발급되도록 로직을 리팩토링하였습니다.

## 💬리뷰 요구사항(선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩터**
	- GitHub 인증 흐름이 개선되어, 인증 요청 시 통합된 로그인 성공 응답을 제공합니다.
	- 인증 콜백 엔드포인트가 `/authentication` 경로로 변경되어, 사용자 경험과 접근성이 향상되었습니다.
	- 이전에 분리되어 있던 인증 처리 방식을 통합하여 서비스의 일관성과 효율성이 증대되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->